### PR TITLE
Add Collection#spreadsheets to return spreadsheets of a collection

### DIFF
--- a/lib/google_spreadsheet.rb
+++ b/lib/google_spreadsheet.rb
@@ -734,7 +734,7 @@ module GoogleSpreadsheet
             title = entry.css("title").text
             url = entry.css(
               "link[@rel='http://schemas.google.com/spreadsheets/2006#worksheetsfeed']")[0]["href"]
-            GoogleSpreadsheet::Spreadsheet.new(self, url, title)
+            GoogleSpreadsheet::Spreadsheet.new(@session, url, title)
           end
         end
         


### PR DESCRIPTION
This method returns all the spreadsheets that exist within a Google Docs
collection.
