### PR TITLE
Add find/create APIs

### DIFF
--- a/lib/google_spreadsheet/session.rb
+++ b/lib/google_spreadsheet/session.rb
@@ -130,6 +130,18 @@ module GoogleSpreadsheet
           return Spreadsheet.new(self, url)
         end
 
+        # Returns GoogleSpreadsheet::Spreadsheet with given +title+.
+        # Returns nil if not found.
+        def spreadsheet_by_title(title)
+          spreadsheets({'title' => title})[0]
+        end
+
+        # Returns GoogleSpreadsheet::Spreadsheet with given +title+.
+        # Returns new GoogleSpreadsheet::Spreadsheet if not found.
+        def spreadsheet_by_title_or_create(title)
+          spreadsheet_by_title(title) || create_spreadsheet(title)
+        end
+
         # Returns GoogleSpreadsheet::Spreadsheet with given +url+. You must specify either of:
         # - URL of the page you open to access the spreadsheet in your browser
         # - URL of worksheet-based feed of the spreadseet

--- a/lib/google_spreadsheet/spreadsheet.rb
+++ b/lib/google_spreadsheet/spreadsheet.rb
@@ -215,6 +215,13 @@ module GoogleSpreadsheet
         def worksheet_by_title(title)
           return self.worksheets.find(){ |ws| ws.title == title }
         end
+        
+
+        # Returns a GoogleSpreadsheet::Worksheet with the given title in the spreadsheet.
+        # Returns added GoogleSpreadsheet::Worksheet if not found.
+        def worksheet_by_title_or_add(title)
+          worksheet_by_title(title) || add_worksheet(title)
+        end
 
         # Adds a new worksheet to the spreadsheet. Returns added GoogleSpreadsheet::Worksheet.
         def add_worksheet(title, max_rows = 100, max_cols = 20)

--- a/test/test_google_spreadsheet.rb
+++ b/test/test_google_spreadsheet.rb
@@ -72,6 +72,10 @@ class TC_GoogleSpreadsheet < Test::Unit::TestCase
       assert_equal("3", ss2.worksheets[0][1, 1])
       assert_equal("hoge", ss2.worksheet_by_title("hoge").title)
       assert_equal(nil, ss2.worksheet_by_title("foo"))
+
+      ss2.worksheet_by_title_or_add("huga")
+      assert_equal("huga", ss2.worksheet_by_title("huga").title)
+
       if RUBY_VERSION >= "1.9.0"
         assert_equal(Encoding::UTF_8, ss2.title.encoding)
         assert_equal(Encoding::UTF_8, ss2.worksheets[0].title.encoding)
@@ -132,6 +136,17 @@ class TC_GoogleSpreadsheet < Test::Unit::TestCase
       ws[2, 1] = "5"
       ws["A2"] = "555"
       assert_equal("555", ws[2, 1])
+
+      ss_by_title = session.spreadsheet_by_title(ss_title)
+      assert_equal(ss_by_title.human_url, ss.human_url)
+
+      sleep 1
+      ss_new_title = "google-spreadsheet-ruby test " + Time.now.strftime("%Y-%m-%d-%H-%M-%S")
+      assert_nil(session.spreadsheet_by_title(ss_new_title))
+
+      ss_new = session.spreadsheet_by_title_or_create(ss_new_title)
+      assert_not_equal(ss_new.human_url, ss.human_url)
+      ss_new.delete()
 
       ss.delete()
       assert_nil(session.spreadsheets("title" => ss_title).


### PR DESCRIPTION
I hope that not found spreadsheet or wheetsheet, return create/add new spreadsheet/worksheet.
- Session#spreadsheet_by_title
- Session#spreadsheet_by_title_or_create
- Spreadsheet#worksheet_by_title_or_add

I implemented those APIs.
